### PR TITLE
Allow environment variables to contain whitespace

### DIFF
--- a/src/circleci-matrix.sh
+++ b/src/circleci-matrix.sh
@@ -158,7 +158,7 @@ process_envs() {
                 info "Env: $line"
                 print_horizontal_rule
 
-                process_commands $line
+                process_commands "$line"
                 info ""
             fi
             ((i=i+1))

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -214,3 +214,11 @@ circleci-matrix() {
     run circleci-matrix --config invalid-config.yml
     echo $output | grep "ERROR: No invalid-config.yml file found!"
 }
+
+@test "should support spaces in single quoted variables" {
+    circleci-matrix --config whitespace_support.yml | grep "^double quoted$"
+}
+
+@test "should support spaces in double quoted variables" {
+    circleci-matrix --config whitespace_support.yml | grep "^single quoted$"
+}

--- a/tests/whitespace_support.yml
+++ b/tests/whitespace_support.yml
@@ -1,0 +1,6 @@
+env:
+    - VERSION="double quoted"
+    - VERSION='single quoted'
+
+command:
+    - echo "$VERSION"


### PR DESCRIPTION
Previously, yaml parsing would fail with EOF errors if environment
variables were quoted strings containing spaces.

This change treats yaml lines as strings when processing commands,
and adds tests for double and single quoted string variables.

Example:

``` yaml
env:
  - VERSION="a b c"
```

results in:

``` shell
$ circleci-matrix

------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
Env: VERSION="a b c"
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
bash: -c: line 0: unexpected EOF while looking for matching `"'
bash: -c: line 1: syntax error: unexpected end of file
```
